### PR TITLE
Remove `swift-actions/setup-swift` step in CI workflow

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -30,11 +30,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Swift
-      uses: swift-actions/setup-swift@v2
-      with:
-        swift-version: ${{ matrix.swift }}
-
     - name: Lint
       run: swift format lint --recursive . --strict
 


### PR DESCRIPTION
Our build job already configures `DEVELOPER_DIR` based on our test matrix, so this step shouldn't be necessary. Removing it should save ~1 minute to each CI run (~50% faster).