### PR TITLE
Add ordered dictionary as input value

### DIFF
--- a/Sources/Jinja/Value.swift
+++ b/Sources/Jinja/Value.swift
@@ -57,6 +57,18 @@ public enum Value: Sendable {
                 orderedDict[key] = try Value(any: value)
             }
             self = .object(orderedDict)
+        case let orderedDict as OrderedDictionary<String, String>:
+            self = .object(orderedDict.mapValues(Value.init))
+        case let orderedDict as OrderedDictionary<String, Any>:
+            self = .object(try orderedDict.mapValues(Value.init))
+        case let orderedDict as OrderedDictionary<String, Any?>:
+            self = .object(try orderedDict.mapValues(Value.init))
+        case let orderedDict as OrderedDictionary<String, OrderedDictionary<String, String>>:
+            self = .object(try orderedDict.mapValues(Value.init))
+        case let orderedDict as OrderedDictionary<String, OrderedDictionary<String, Any>>:
+            self = .object(try orderedDict.mapValues(Value.init))
+        case let orderedDict as OrderedDictionary<String, OrderedDictionary<String, Any?>>:
+            self = .object(try orderedDict.mapValues(Value.init))
         case let macro as Macro:
             self = .macro(macro)
         default:

--- a/Tests/JinjaTests/ValueTests.swift
+++ b/Tests/JinjaTests/ValueTests.swift
@@ -31,6 +31,28 @@ struct ValueTests {
         } else {
             Issue.record("Expected object value")
         }
+        
+        let orderedDict = ["0": "a", "1": "b"] as OrderedDictionary
+        let orderedDictValue = try Value(any: orderedDict)
+        if case let .object(dict) = orderedDictValue {
+            #expect(dict.index(forKey: "0") == 0)
+            #expect(dict["0"] == Value.string("a"))
+            #expect(dict.index(forKey: "1") == 1)
+            #expect(dict["1"] == Value.string("b"))
+        } else {
+            Issue.record("Expected object value")
+        }
+        
+        let orderedNestedDict = ["0": orderedDict, "1": orderedDict] as OrderedDictionary
+        let orderedNestedDictValue = try Value(any: orderedNestedDict)
+        if case let .object(dict) = orderedNestedDictValue {
+            #expect(dict.index(forKey: "0") == 0)
+            #expect(dict["0"] == .object(["0": .string("a"), "1": .string("b")]))
+            #expect(dict.index(forKey: "1") == 1)
+            #expect(dict["1"] == .object(["0": .string("a"), "1": .string("b")]))
+        } else {
+            Issue.record("Expected object value")
+        }
 
         #expect(throws: JinjaError.self) {
             _ = try Value(any: NSObject())


### PR DESCRIPTION
## What

It was possible to pass `OrderedDictionary` directly as an argument into the render function. However, after the `2.0.0` update it now throws a runtime error indicating that the value is not convertible. This PR brings back support for this feature.

## Notes

You may notice that `OrderedDictionary` requires explicit casting for different generic types. While `Dictionary` is backed by `NSDictionary` and uses type‑erased values under the hood, this is not the case for `OrderedDictionary`, because it is a fully generic Swift type.

For example, given such a declaration:

```swift
let orderedDictionary: OrderedDictionary<String, String> = [
    "1": "a",
    "2": "b",
]
```

Attempting to cast it will give the following results:

```
(lldb) po orderedDictionary is OrderedDictionary<String, String>
true
(lldb) po orderedDictionary is OrderedDictionary<String, Any>
false
(lldb) po orderedDictionary is OrderedDictionary<String, Any?>
false
```

And if we change the declaration to an `OrderedDictionary<String, Any>` type:

```
(lldb) po orderedDictionary is OrderedDictionary<String, String>
false
(lldb) po orderedDictionary is OrderedDictionary<String, Any>
true
(lldb) po orderedDictionary is OrderedDictionary<String, Any?>
false
```

If we do the same for a default dictionary:

```swift
let dictionary: [String: String] = [
    "1": "a",
    "2": "b",
]
```

```
(lldb) po dictionary is [String: String]
true
(lldb) po dictionary is [String: Any]
true
(lldb) po dictionary is [String: Any?]
true
```

A possible solution here would be to change `enum Value` into something like `protocol ValueRepresentable` and cast it as `OrderedDictionary<String, ValueRepresentable>`, but that would require many breaking changes, so I’m not doing it.