### PR TITLE
Fix `Value(any:)` initializer handling of `Value` argument

### DIFF
--- a/Sources/Jinja/Value.swift
+++ b/Sources/Jinja/Value.swift
@@ -36,6 +36,8 @@ public enum Value: Sendable {
     /// - Throws: `JinjaError.runtime` if the value type cannot be converted
     public init(any value: Any?) throws {
         switch value {
+        case let value as Value:
+            self = value
         case nil:
             self = .null
         case let str as String:

--- a/Tests/JinjaTests/ValueTests.swift
+++ b/Tests/JinjaTests/ValueTests.swift
@@ -35,6 +35,15 @@ struct ValueTests {
         #expect(throws: JinjaError.self) {
             _ = try Value(any: NSObject())
         }
+
+        let orderedDictValue = try Value(any: Value.object(["key": "value", "num": 42]))
+        if case let .object(dict) = orderedDictValue {
+            #expect(dict["key"] == Value.string("value"))
+            #expect(dict["num"] == Value.int(42))
+            #expect(Array(dict.keys) == ["key", "num"])
+        } else {
+            Issue.record("Expected object value")
+        }
     }
 
     @Test("Literal conformances")


### PR DESCRIPTION
Alternative to #37 

As proposed by https://github.com/huggingface/swift-jinja/pull/37#issuecomment-3479966840, this PR fixes a problem that arises when trying to pass `Value` objects to `Tokenizer.applyChatTemplate` in swift-transformers.