### PR TITLE
Expose error descriptions

### DIFF
--- a/Sources/Jinja/Error.swift
+++ b/Sources/Jinja/Error.swift
@@ -1,5 +1,7 @@
+import Foundation
+
 /// Errors that can occur during Jinja template processing.
-public enum JinjaError: Error, Sendable {
+public enum JinjaError: Error, Sendable, LocalizedError {
     /// Error during tokenization of template source.
     case lexer(String)
     /// Error during parsing of tokens into AST.
@@ -8,4 +10,13 @@ public enum JinjaError: Error, Sendable {
     case runtime(String)
     /// Error due to invalid template syntax.
     case syntax(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .lexer(let message): return "Lexer error: \(message)"
+        case .parser(let message): return "Parser error: \(message)"
+        case .runtime(let message): return "Runtime error: \(message)"
+        case .syntax(let message): return "Syntax error: \(message)"
+        }
+    }
 }


### PR DESCRIPTION
This change makes errors conform to `LocalizedError` so that error messages can be bubbled up in apps that consume this library.