### PR TITLE
Clean up JinjaError

### DIFF
--- a/Sources/Jinja/Error.swift
+++ b/Sources/Jinja/Error.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Errors that can occur during Jinja template processing.
-public enum JinjaError: Error, Sendable, LocalizedError {
+public enum JinjaError: LocalizedError {
     /// Error during tokenization of template source.
     case lexer(String)
     /// Error during parsing of tokens into AST.


### PR DESCRIPTION
Sorry, I should have done some more testing. I was wondering why the error message wasn't bubbling up even after adding `LocalizedError` conformance. In fact, it looks like the error message will be propagated if we remove `Error` and `Sendable` conformance, which `JinjaError` previously had but are not necessary after adding `LocalizedError`. After merging this, https://github.com/huggingface/swift-transformers/pull/292 can be reverted.