### PR TITLE
Enumerate sorted keys when initializing from `Dictionary` in `Value.init(any:)`

### DIFF
--- a/Sources/Jinja/Value.swift
+++ b/Sources/Jinja/Value.swift
@@ -55,8 +55,8 @@ public enum Value: Sendable {
             self = .array(values)
         case let dict as [String: Any?]:
             var orderedDict = OrderedDictionary<String, Value>()
-            for (key, value) in dict {
-                orderedDict[key] = try Value(any: value)
+            for key in dict.keys.sorted() {
+                orderedDict[key] = try Value(any: dict[key] ?? nil)
             }
             self = .object(orderedDict)
         case let macro as Macro:

--- a/Sources/Jinja/Value.swift
+++ b/Sources/Jinja/Value.swift
@@ -55,8 +55,8 @@ public enum Value: Sendable {
             self = .array(values)
         case let dict as [String: Any?]:
             var orderedDict = OrderedDictionary<String, Value>()
-            for key in dict.keys.sorted() {
-                orderedDict[key] = try Value(any: dict[key] ?? nil)
+            for (key, value) in dict.sorted(by: { $0.key < $1.key }) {
+                orderedDict[key] = try Value(any: value)
             }
             self = .object(orderedDict)
         case let macro as Macro:

--- a/Tests/JinjaTests/ValueTests.swift
+++ b/Tests/JinjaTests/ValueTests.swift
@@ -82,6 +82,22 @@ struct ValueTests {
         #expect(nilValue == Value.null)
     }
 
+    @Test("Dictionary conversion via any is key-sorted")
+    func initFromAnyDictionarySortsKeys() throws {
+        let source: [String: Any?] = [
+            "text": "hello",
+            "priority": 1,
+            "is_urgent": true,
+        ]
+
+        let value = try Value(any: source)
+        if case let .object(dict) = value {
+            #expect(Array(dict.keys) == ["is_urgent", "priority", "text"])
+        } else {
+            Issue.record("Expected object value")
+        }
+    }
+
     @Test("CustomStringConvertible conformance")
     func description() {
         #expect(Value.string("test").description == "test")


### PR DESCRIPTION
Resolves #53 
Follow-up to #52 