### PR TITLE
Enforce deterministic key ordering in globals and macros

### DIFF
--- a/Sources/Jinja/Globals.swift
+++ b/Sources/Jinja/Globals.swift
@@ -207,7 +207,7 @@ public enum Globals: Sendable {
         _ env: Environment
     ) throws -> Value {
         var orderedDict = OrderedDictionary<String, Value>()
-        for (key, value) in kwargs {
+        for (key, value) in kwargs.sorted(by: { $0.key < $1.key }) {
             orderedDict[key] = value
         }
         return .object(orderedDict)
@@ -343,7 +343,7 @@ public enum Globals: Sendable {
         _ env: Environment
     ) throws -> Value {
         var namespaceDict = OrderedDictionary<String, Value>()
-        for (key, value) in kwargs {
+        for (key, value) in kwargs.sorted(by: { $0.key < $1.key }) {
             namespaceDict[key] = value
         }
         return .object(namespaceDict)

--- a/Sources/Jinja/Macro.swift
+++ b/Sources/Jinja/Macro.swift
@@ -50,7 +50,7 @@ extension Macro: Codable {
         var orderedDictionary: OrderedDictionary<String, Expression> = [:]
 
         let decodedDefaults = try container.decode([String: Expression].self, forKey: .defaults)
-        for key in decodedDefaults.keys {
+        for key in decodedDefaults.keys.sorted() {
             orderedDictionary[key] = decodedDefaults[key]
         }
         defaults = orderedDictionary

--- a/Tests/JinjaTests/GlobalsTests.swift
+++ b/Tests/JinjaTests/GlobalsTests.swift
@@ -188,6 +188,28 @@ struct GlobalsTests {
         #expect(obj["b"] == .int(2))
     }
 
+    @Test("dict result has deterministic key ordering")
+    func dictKwargsOrdering() throws {
+        let permutations: [[(String, Value)]] = [
+            [("text", .string("hello")), ("priority", .int(1)), ("is_urgent", .boolean(true))],
+            [("text", .string("hello")), ("is_urgent", .boolean(true)), ("priority", .int(1))],
+            [("priority", .int(1)), ("text", .string("hello")), ("is_urgent", .boolean(true))],
+            [("priority", .int(1)), ("is_urgent", .boolean(true)), ("text", .string("hello"))],
+            [("is_urgent", .boolean(true)), ("text", .string("hello")), ("priority", .int(1))],
+            [("is_urgent", .boolean(true)), ("priority", .int(1)), ("text", .string("hello"))],
+        ]
+
+        for pairs in permutations {
+            let kwargs = Dictionary(uniqueKeysWithValues: pairs)
+            let result = try Globals.dict([], kwargs, env)
+            guard case let .object(obj) = result else {
+                #expect(Bool(false), "Expected object result")
+                continue
+            }
+            #expect(Array(obj.keys) == ["is_urgent", "priority", "text"])
+        }
+    }
+
     // MARK: - cycler
 
     @Test("cycler cycles through values")
@@ -252,6 +274,28 @@ struct GlobalsTests {
             return
         }
         #expect(obj["x"] == .int(1))
+    }
+
+    @Test("namespace result has deterministic key ordering")
+    func namespaceKwargsOrdering() throws {
+        let permutations: [[(String, Value)]] = [
+            [("text", .string("hello")), ("priority", .int(1)), ("is_urgent", .boolean(true))],
+            [("text", .string("hello")), ("is_urgent", .boolean(true)), ("priority", .int(1))],
+            [("priority", .int(1)), ("text", .string("hello")), ("is_urgent", .boolean(true))],
+            [("priority", .int(1)), ("is_urgent", .boolean(true)), ("text", .string("hello"))],
+            [("is_urgent", .boolean(true)), ("text", .string("hello")), ("priority", .int(1))],
+            [("is_urgent", .boolean(true)), ("priority", .int(1)), ("text", .string("hello"))],
+        ]
+
+        for pairs in permutations {
+            let kwargs = Dictionary(uniqueKeysWithValues: pairs)
+            let result = try Globals.namespace([], kwargs, env)
+            guard case let .object(obj) = result else {
+                #expect(Bool(false), "Expected object result")
+                continue
+            }
+            #expect(Array(obj.keys) == ["is_urgent", "priority", "text"])
+        }
     }
 
     // MARK: - lipsum

--- a/Tests/JinjaTests/MacroTests.swift
+++ b/Tests/JinjaTests/MacroTests.swift
@@ -57,6 +57,23 @@ struct MacroTests {
         #expect(decoded.defaults["class"] == macro.defaults["class"])
     }
 
+    @Test("Decoded defaults are key-sorted")
+    func decodedDefaultsAreKeySorted() throws {
+        let macro = Macro(
+            name: "render",
+            parameters: ["a", "z"],
+            defaults: ["z": .integer(1), "a": .integer(2)],
+            body: [.text("x")]
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(macro)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(Macro.self, from: data)
+
+        #expect(Array(decoded.defaults.keys) == ["a", "z"])
+    }
+
     @Test("Codable round-trip with empty defaults")
     func codableRoundTripEmptyDefaults() throws {
         let macro = Macro(


### PR DESCRIPTION
Follow-up to #54 

This PR takes a further step to fix some more instances where dictionary keys might be encoded nondeterministically.