### PR TITLE
fix(parser): for-loop iterable accepts binary expressions

### DIFF
--- a/Sources/Jinja/Parser.swift
+++ b/Sources/Jinja/Parser.swift
@@ -183,7 +183,7 @@ public struct Parser: Sendable {
 
         try consume(.in, message: "Expected 'in' in for loop.")
 
-        let iterableExpr = try parseFilter()
+        let iterableExpr = try parseOr()
         var testExpr: Expression?
 
         if match(.if) {

--- a/Tests/JinjaTests/MistralRealTemplateTests.swift
+++ b/Tests/JinjaTests/MistralRealTemplateTests.swift
@@ -1,0 +1,35 @@
+import Testing
+import Foundation
+@testable import Jinja
+
+/// Verifies for-loop iterable accepts arbitrary expressions (not only
+/// names + filters). Real-world repro: Mistral-Medium-3.5 chat
+/// template uses `{%- for message in loop_messages + [{...}] %}`
+/// which `parseFilter()` rejected with "Expected '%}' after for
+/// loop.. Got plus instead". Fix at Parser.swift:186 swaps to
+/// parseExpression().
+@Test func forLoopIterableAcceptsBinaryPlus() throws {
+    let src = """
+{%- set base = ["a", "b"] -%}
+{%- for x in base + ["c"] -%}{{- x -}}{%- endfor -%}
+"""
+    let tmpl = try Template(src)
+    let out = try tmpl.render([:])
+    #expect(out == "abc")
+}
+
+@Test func mistral3RealNativeTemplateParses() throws {
+    // Inline a minimum repro of the mistral3 construct so this test
+    // doesn't depend on a bundle being on disk.
+    let src = """
+{%- set loop_messages = messages -%}
+{%- for message in loop_messages + [{'role': '__sentinel__'}] -%}
+  {%- if message.role != '__sentinel__' -%}
+    {{- '[INST]' -}}{{- message.content -}}{{- '[/INST]' -}}
+  {%- endif -%}
+{%- endfor -%}
+"""
+    let tmpl = try Template(src)
+    let out = try tmpl.render(["messages": [["role": "user", "content": "Hi"]]])
+    #expect(out == "[INST]Hi[/INST]")
+}


### PR DESCRIPTION
## Problem

`parseForStatement` (Parser.swift:186) calls `parseFilter()` for the for-loop iterable expression, which only handles factor + `|filter` syntax. Real-world chat templates use binary operators in the iterable position — for example, the official Mistral-Medium-3.5 chat template uses:

\`\`\`jinja
{%- for message in loop_messages + [{'role': '__sentinel__'}] -%}
\`\`\`

…to append a sentinel to flush the last group. The `+` token currently triggers `Expected '%}' after for loop.. Got plus instead`.

## Fix

Lift the iterable parser from `parseFilter()` to `parseOr()`. `parseOr()` is the highest precedence below ternary — it handles all binary + comparison + logical operators, but does NOT consume the for-loop's own `if test` filter token (which `parseExpression()` would, via `parseTernary` → `match(.if)`).

Concretely `parseOr()` covers:
- `or`, `and`, `not`, `in`, `not in`, `is`, `is not`
- `==`, `!=`, `<`, `<=`, `>`, `>=`
- `+`, `-`, `~`
- `*`, `/`, `//`, `%`, `**`
- factor (call, subscript, attribute, literal)
- `|filter` chains

…while leaving `if/else` outside its grammar so `for x in iter if test` continues to parse.

## Tests

- All 756 existing tests pass (verified locally).
- Added 2 regression tests in `Tests/JinjaTests/MistralRealTemplateTests.swift`:
  - `forLoopIterableAcceptsBinaryPlus` — minimum repro: `for x in base + ["c"]` renders `"abc"`.
  - `mistral3RealNativeTemplateParses` — inline minimum repro of the Mistral 3 construct, asserts parse + render produce `[INST]Hi[/INST]`.

## Real-world impact

Verified end-to-end against the actual Mistral-Medium-3.5-128B chat_template.jinja from the upstream model bundle. With this fix the native template parses and renders the full `[MODEL_SETTINGS]{"reasoning_effort": "..."}[/MODEL_SETTINGS][INST]…[/INST]` framing the model was trained on. Without the fix, downstreams have to write hand-rolled minimal fallback templates that drop the reasoning_effort plumbing.

Filed from the osaurus-ai fork at https://github.com/osaurus-ai/swift-jinja/commit/58d21aa5