### PR TITLE
Bridge non-Int integers and nested Optionals in Value.init(any:)

### DIFF
--- a/Sources/Jinja/Value.swift
+++ b/Sources/Jinja/Value.swift
@@ -45,8 +45,9 @@ public enum Value: Sendable {
         case let int as Int:
             self = .int(int)
         case let int as any BinaryInteger:
-            // Bridge non-`Int` integer widths (e.g. `Int64` from a JSON round-trip,
-            // `Int32`, `UInt…`). Falls back to `.double` if the value doesn't fit in `Int`.
+            // Bridge non-`Int` integer widths,
+            // for example `Int64` from a JSON round-trip, `Int32`, or `UInt…`.
+            // Fall back to `.double` when the value doesn't fit in `Int`.
             self = Int(exactly: int).map(Value.int) ?? .double(Double(int))
         case let double as Double:
             self = .double(double)
@@ -66,19 +67,18 @@ public enum Value: Sendable {
         case let macro as Macro:
             self = .macro(macro)
         default:
-            // A value that is itself an Optional — e.g. a missing template member
-            // arriving as `Optional<Any>.some(nil)` — degrades to Jinja null rather
-            // than throwing. `case nil` above only catches a top-level `nil`.
-            if case let .some(inner) = value {
-                let mirror = Mirror(reflecting: inner)
-                if mirror.displayStyle == .optional {
-                    self = try Value(any: mirror.children.first?.value)
-                    return
-                }
+            // `value` is guaranteed to be non-nil here because `case nil` is handled above.
+            // If it's a non-nil `Optional` erased into `Any` —
+            // for example, a missing template member that arrives as `Optional<Any>.some(.none)` —
+            // unwrap it and retry so that it degrades to null.
+            let unwrapped = value!
+            let mirror = Mirror(reflecting: unwrapped)
+            guard mirror.displayStyle == .optional else {
+                throw JinjaError.runtime(
+                    "Cannot convert value of type \(type(of: unwrapped)) to Jinja Value"
+                )
             }
-            throw JinjaError.runtime(
-                "Cannot convert value of type \(type(of: value)) to Jinja Value"
-            )
+            self = try Value(any: mirror.children.first?.value)
         }
     }
 

--- a/Sources/Jinja/Value.swift
+++ b/Sources/Jinja/Value.swift
@@ -44,6 +44,10 @@ public enum Value: Sendable {
             self = .string(str)
         case let int as Int:
             self = .int(int)
+        case let int as any BinaryInteger:
+            // Bridge non-`Int` integer widths (e.g. `Int64` from a JSON round-trip,
+            // `Int32`, `UInt…`). Falls back to `.double` if the value doesn't fit in `Int`.
+            self = Int(exactly: int).map(Value.int) ?? .double(Double(int))
         case let double as Double:
             self = .double(double)
         case let float as Float:
@@ -62,6 +66,16 @@ public enum Value: Sendable {
         case let macro as Macro:
             self = .macro(macro)
         default:
+            // A value that is itself an Optional — e.g. a missing template member
+            // arriving as `Optional<Any>.some(nil)` — degrades to Jinja null rather
+            // than throwing. `case nil` above only catches a top-level `nil`.
+            if case let .some(inner) = value {
+                let mirror = Mirror(reflecting: inner)
+                if mirror.displayStyle == .optional {
+                    self = try Value(any: mirror.children.first?.value)
+                    return
+                }
+            }
             throw JinjaError.runtime(
                 "Cannot convert value of type \(type(of: value)) to Jinja Value"
             )

--- a/Tests/JinjaTests/ValueTests.swift
+++ b/Tests/JinjaTests/ValueTests.swift
@@ -46,6 +46,28 @@ struct ValueTests {
         }
     }
 
+    @Test("Initialization from non-Int integer widths")
+    func initFromIntegerWidths() throws {
+        // JSON schema integers can arrive boxed as Int64/Int32/UInt; all must bridge.
+        #expect(try Value(any: Int64(0)) == Value.int(0))
+        #expect(try Value(any: Int64(-7)) == Value.int(-7))
+        #expect(try Value(any: Int32(42)) == Value.int(42))
+        #expect(try Value(any: UInt(5)) == Value.int(5))
+        #expect(try Value(any: UInt8(255)) == Value.int(255))
+        // Out-of-Int-range falls back to a double rather than trapping.
+        #expect(try Value(any: UInt64.max) == Value.double(Double(UInt64.max)))
+    }
+
+    @Test("Nested Optionals degrade to null instead of throwing")
+    func initFromNestedOptional() throws {
+        // A missing template member arrives as Optional<Any>.some(nil); it must
+        // become Jinja null, not a runtime throw.
+        let nestedNone: Any? = .some(Optional<Any>.none as Any)
+        #expect(try Value(any: nestedNone) == Value.null)
+        let doublyNested: Any? = .some(Optional<Any>.some(Optional<Any>.none as Any) as Any)
+        #expect(try Value(any: doublyNested) == Value.null)
+    }
+
     @Test("Literal conformances")
     func literals() {
         let stringValue: Value = "test"


### PR DESCRIPTION
## Summary

`Value.init(any:)` throws on two inputs that arise routinely when rendering chat templates whose tool definitions carry a JSON Schema. Both surface as `JinjaError.runtime("Cannot convert value of type … to Jinja Value")` and abort the whole template render.

### Bug 1 — non-`Int` integer widths are not bridged
The only integer case is `case let int as Int`. An integer boxed as `Int64` (e.g. from a JSON round-trip), `Int32`, or any unsigned width fails `as? Int` and falls through to `default:`, throwing. Any tool schema with an integer literal (`minimum`/`maximum`/`minLength`/`minItems`/…) trips this.

**Fix:** add `case let int as any BinaryInteger` mapping to `.int`, falling back to `.double` when the value doesn't fit in `Int`.

### Bug 2 — a nested `Optional` crashes instead of degrading to null
A missing template member arrives as `Optional<Any>.some(nil)`. `case nil` only catches a *top-level* `nil`, so the wrapped `.none` reaches `default:` and throws. Accessing an absent member should degrade to Jinja null.

**Fix:** in `default:`, reflect the value with `Mirror`; if it is itself an `.optional`, recurse on its wrapped value (empty → `.null`) before throwing.

## Tests

Two new `ValueTests` cases:
- `initFromIntegerWidths` — `Int64`/`Int32`/`UInt`/`UInt8` bridge to `.int`; `UInt64.max` falls back to `.double`.
- `initFromNestedOptional` — singly- and doubly-nested `Optional<Any>.none` become `.null`.

Both fail on the pre-fix `Value.swift` (each throws the runtime error) and pass after. Full suite: `swift format lint --recursive . --strict`, `swift build`, and `swift test` (769/769) all green.