### PR TITLE
Fix mis-lexing of literal `}}` in template text

### DIFF
--- a/Sources/Jinja/Lexer.swift
+++ b/Sources/Jinja/Lexer.swift
@@ -186,35 +186,37 @@ public enum Lexer: Sendable {
             }
         }
 
-        // Check for closing delimiters
-        if char == "}" {
-            let nextIndex = source.index(after: position)
-            if nextIndex < source.endIndex && source[nextIndex] == "}" && curlyBracketDepth == 0 {
-                let endIndex = source.index(after: nextIndex)
-                return (
-                    Token(
-                        kind: .closeExpression,
-                        value: source[position ..< endIndex],
-                        position: charPosition
-                    ), endIndex
-                )
+        // Closing delimiters are only meaningful inside {{ ... }} / {% ... %}
+        if inTag {
+            if char == "}" {
+                let nextIndex = source.index(after: position)
+                if nextIndex < source.endIndex && source[nextIndex] == "}"
+                    && curlyBracketDepth == 0
+                {
+                    let endIndex = source.index(after: nextIndex)
+                    return (
+                        Token(
+                            kind: .closeExpression,
+                            value: source[position ..< endIndex],
+                            position: charPosition
+                        ), endIndex
+                    )
+                }
             }
-        }
-        if char == "%" {
-            let nextIndex = source.index(after: position)
-            if nextIndex < source.endIndex && source[nextIndex] == "}" {
-                let endIndex = source.index(after: nextIndex)
-                return (
-                    Token(
-                        kind: .closeStatement,
-                        value: source[position ..< endIndex],
-                        position: charPosition
-                    ), endIndex
-                )
+            if char == "%" {
+                let nextIndex = source.index(after: position)
+                if nextIndex < source.endIndex && source[nextIndex] == "}" {
+                    let endIndex = source.index(after: nextIndex)
+                    return (
+                        Token(
+                            kind: .closeStatement,
+                            value: source[position ..< endIndex],
+                            position: charPosition
+                        ), endIndex
+                    )
+                }
             }
-        }
-
-        if !inTag {
+        } else {
             return extractTextToken(from: source, at: position)
         }
 
@@ -349,20 +351,10 @@ public enum Lexer: Sendable {
             let char = source[pos]
             let nextIndex = source.index(after: pos)
 
-            if nextIndex <= source.endIndex {
-                if char == "{" && nextIndex < source.endIndex {
-                    let nextChar = source[nextIndex]
-                    if nextChar == "{" || nextChar == "%" || nextChar == "#" {
-                        break
-                    }
-                }
-                if char == "}" && nextIndex < source.endIndex && source[nextIndex] == "}" {
-                    break
-                }
-                if char == "%" && nextIndex < source.endIndex && source[nextIndex] == "}" {
-                    break
-                }
-                if char == "#" && nextIndex < source.endIndex && source[nextIndex] == "}" {
+            // Only opening delimiters end a text run; bare }}, %}, and #} are literal text.
+            if char == "{" && nextIndex < source.endIndex {
+                let nextChar = source[nextIndex]
+                if nextChar == "{" || nextChar == "%" || nextChar == "#" {
                     break
                 }
             }

--- a/Tests/JinjaTests/TemplateTests.swift
+++ b/Tests/JinjaTests/TemplateTests.swift
@@ -71,6 +71,27 @@ struct TemplateTests {
         #expect(try rendered == Template(nodes: nodes).render(context))
     }
 
+    @Test("Literal closing braces in text are not close-expression delimiters")
+    func literalClosingBracesInText() throws {
+        // https://github.com/huggingface/swift-jinja/issues/63
+        let string = #"{"parameters": {}}"#
+        let context: Context = [:]
+
+        let tokens = try Lexer.tokenize(string)
+        #expect(
+            tokens == [
+                Token(kind: .text, value: #"{"parameters": {}}"#, position: 0),
+                Token(kind: .eof, value: "", position: 18),
+            ]
+        )
+
+        let nodes = try Parser.parse(tokens)
+        #expect(nodes == [.text(#"{"parameters": {}}"#)])
+
+        let rendered = try Template(string).render(context)
+        #expect(rendered == #"{"parameters": {}}"#)
+    }
+
     @Test("Text nodes")
     func textNodes() throws {
         let string = #"0{{ 'A' }}1{{ 'B' }}{{ 'C' }}2{{ 'D' }}3"#


### PR DESCRIPTION
Fixes #63 