### PR TITLE
Support integer keys in Jinja object literals

### DIFF
--- a/Sources/Jinja/AST.swift
+++ b/Sources/Jinja/AST.swift
@@ -40,7 +40,7 @@ public indirect enum Expression: Hashable, Codable, Sendable {
     case tuple([Expression])
 
     /// Object literal with key-value pairs.
-    case object(OrderedDictionary<String, Expression>)
+    case object(OrderedDictionary<ObjectKey, Expression>)
 
     /// Variable or function identifier reference.
     case identifier(String)

--- a/Sources/Jinja/Filters.swift
+++ b/Sources/Jinja/Filters.swift
@@ -223,7 +223,7 @@ public enum Filters {
             if dict.isEmpty { return .undefined }
             let randomIndex = dict.keys.indices.randomElement()!
             let randomKey = dict.keys[randomIndex]
-            return .string(randomKey)
+            return Value(randomKey)
         default:
             return .undefined
         }
@@ -666,7 +666,7 @@ public enum Filters {
         }
         let reverse = arguments["reverse"]!.isTruthy
 
-        let sortedPairs: [(key: String, value: Value)]
+        let sortedPairs: [(key: ObjectKey, value: Value)]
         if by == "value" {
             sortedPairs = dict.sorted { a, b in
                 let comparison =
@@ -677,16 +677,13 @@ public enum Filters {
             }
         } else {
             sortedPairs = dict.sorted { a, b in
-                let comparison =
-                    caseSensitive
-                    ? a.key.compare(b.key)
-                    : a.key.localizedCaseInsensitiveCompare(b.key)
+                let comparison = a.key.compare(b.key, options: caseSensitive ? [] : [.caseInsensitive])
                 return reverse ? comparison == .orderedDescending : comparison == .orderedAscending
             }
         }
 
         let resultArray = sortedPairs.map { key, value in
-            Value.array([.string(key), value])
+            Value.array([Value(key), value])
         }
         return .array(resultArray)
     }
@@ -983,9 +980,12 @@ public enum Filters {
         var needsSpace = false
         for (key, value) in dict {
             if value == .null || value == .undefined { continue }
+            let keyString = key.stringValue
             // Validate key doesn't contain invalid characters
-            if key.contains(" ") || key.contains("/") || key.contains(">") || key.contains("=") {
-                throw JinjaError.runtime("Invalid character in XML attribute key: '\(key)'")
+            if keyString.contains(" ") || keyString.contains("/") || keyString.contains(">")
+                || keyString.contains("=")
+            {
+                throw JinjaError.runtime("Invalid character in XML attribute key: '\(keyString)'")
             }
             let escapedValue = value.description
                 .replacingOccurrences(of: "&", with: "&amp;")
@@ -993,7 +993,7 @@ public enum Filters {
                 .replacingOccurrences(of: ">", with: "&gt;")
                 .replacingOccurrences(of: "\"", with: "&quot;")
             if needsSpace { result += " " }
-            result += "\(key)=\"\(escapedValue)\""
+            result += "\(keyString)=\"\(escapedValue)\""
             needsSpace = true
         }
         if autospace && !result.isEmpty {
@@ -1586,7 +1586,7 @@ public enum Filters {
         if case .object(let dict) = value {
             var components = URLComponents()
             components.queryItems = dict.map { key, value in
-                URLQueryItem(name: key, value: value.description)
+                URLQueryItem(name: key.stringValue, value: value.description)
             }
             return .string(components.percentEncodedQuery ?? "")
         }
@@ -1840,7 +1840,7 @@ public enum Filters {
 
         if case let .object(obj) = value {
             let pairs = obj.map { key, value in
-                Value.array([.string(key), value])
+                Value.array([Value(key), value])
             }
             return .array(pairs)
         }
@@ -1874,7 +1874,7 @@ public enum Filters {
             case let .object(dict):
                 if dict.isEmpty { return "{}" }
                 let items = dict.map { key, value in
-                    "\(indentString)  \"\(key)\": \(prettyPrint(value, indent: indent + 1))"
+                    "\(indentString)  \"\(key.stringValue)\": \(prettyPrint(value, indent: indent + 1))"
                 }
                 return "{\n" + items.joined(separator: ",\n") + "\n\(indentString)}"
             case let .string(str):
@@ -2103,7 +2103,7 @@ private func resolveAttributeValue(_ item: Value, attribute: Value) throws -> Va
             }
             return .undefined
         case let .object(values):
-            return values[String(index)] ?? .undefined
+            return values[.int(index)] ?? values[.string(String(index))] ?? .undefined
         default:
             return .undefined
         }

--- a/Sources/Jinja/Globals.swift
+++ b/Sources/Jinja/Globals.swift
@@ -206,9 +206,9 @@ public enum Globals: Sendable {
         _ kwargs: [String: Value],
         _ env: Environment
     ) throws -> Value {
-        var orderedDict = OrderedDictionary<String, Value>()
+        var orderedDict = OrderedDictionary<ObjectKey, Value>()
         for (key, value) in kwargs.sorted(by: { $0.key < $1.key }) {
-            orderedDict[key] = value
+            orderedDict[.string(key)] = value
         }
         return .object(orderedDict)
     }
@@ -265,7 +265,7 @@ public enum Globals: Sendable {
 
         let cyclerInstance = Cycler(items: args)
 
-        var cyclerDict = OrderedDictionary<String, Value>()
+        var cyclerDict = OrderedDictionary<ObjectKey, Value>()
         cyclerDict["current"] = cyclerInstance.current
         cyclerDict["next"] = .function { (_, _, _) throws -> Value in
             return cyclerInstance.next()
@@ -342,9 +342,9 @@ public enum Globals: Sendable {
         _ kwargs: [String: Value],
         _ env: Environment
     ) throws -> Value {
-        var namespaceDict = OrderedDictionary<String, Value>()
+        var namespaceDict = OrderedDictionary<ObjectKey, Value>()
         for (key, value) in kwargs.sorted(by: { $0.key < $1.key }) {
-            namespaceDict[key] = value
+            namespaceDict[.string(key)] = value
         }
         return .object(namespaceDict)
     }

--- a/Sources/Jinja/Interpreter.swift
+++ b/Sources/Jinja/Interpreter.swift
@@ -364,19 +364,19 @@ public enum Interpreter {
                     let items: [Value]
                     switch loopVar {
                     case .single:
-                        items = entries.map { .string($0.key) }
+                        items = entries.map { Value($0.key) }
                     case .tuple:
-                        items = entries.map { .array([.string($0.key), $0.value]) }
+                        items = entries.map { .array([Value($0.key), $0.value]) }
                     }
                     for (index, (key, value)) in entries.enumerated() {
                         switch loopVar {
                         case let .single(varName):
                             // Single variable gets the key
-                            childEnv[varName] = .string(key)
+                            childEnv[varName] = Value(key)
                         case let .tuple(varNames):
                             // Tuple unpacking: first gets key, second gets value
                             if varNames.count >= 1 {
-                                childEnv[varNames[0]] = .string(key)
+                                childEnv[varNames[0]] = Value(key)
                             }
                             if varNames.count >= 2 {
                                 childEnv[varNames[1]] = value
@@ -579,8 +579,8 @@ public enum Interpreter {
 
             if computed {
                 let propertyValue = try evaluateExpression(propertyExpr, env: env)
-                guard case let .string(key) = propertyValue else {
-                    throw JinjaError.runtime("Computed property key must be a string")
+                guard let key = ObjectKey(propertyValue) else {
+                    throw JinjaError.runtime("Computed property key must be a string or integer")
                 }
                 if case var .object(dict) = objectValue {
                     dict[key] = value
@@ -594,7 +594,7 @@ public enum Interpreter {
                     throw JinjaError.runtime("Property assignment requires identifier")
                 }
                 if case var .object(dict) = objectValue {
-                    dict[propertyName] = value
+                    dict[.string(propertyName)] = value
                     // Update the object in the environment
                     if case let .identifier(name) = objectExpr {
                         env.setInChain(name: name, value: .object(dict))
@@ -740,7 +740,10 @@ public enum Interpreter {
             return arr[safeIndex]
 
         case let (.object(obj), .string(key)):
-            return obj[key] ?? .undefined
+            return obj[.string(key)] ?? .undefined
+
+        case let (.object(obj), .int(key)):
+            return obj[.int(key)] ?? .undefined
 
         case let (.string(str), .int(index)):
             let safeIndex = index < 0 ? str.count + index : index
@@ -801,7 +804,7 @@ public enum Interpreter {
         index: Int
     ) -> Value {
         let count = items.count
-        var loopContext: OrderedDictionary<String, Value> = [
+        var loopContext: OrderedDictionary<ObjectKey, Value> = [
             "index": .int(index + 1),
             "index0": .int(index),
             "first": .boolean(index == 0),

--- a/Sources/Jinja/Parser.swift
+++ b/Sources/Jinja/Parser.swift
@@ -580,28 +580,42 @@ public struct Parser: Sendable {
             return .array(elements)
         case .openBrace:
             advance()
-            var pairs: OrderedDictionary<String, Expression> = [:]
+            var pairs: OrderedDictionary<ObjectKey, Expression> = [:]
             if !check(.closeBrace) {
                 repeat {
-                    let keyToken: Token
+                    let key: ObjectKey
                     if check(.string) {
-                        keyToken = try consume(
+                        let keyToken = try consume(
                             .string,
                             message: "Expected string literal for object key."
                         )
+                        key = .string(String(keyToken.value))
                     } else if check(.identifier) {
-                        keyToken = try consume(
+                        let keyToken = try consume(
                             .identifier,
                             message: "Expected identifier for object key."
                         )
+                        key = .string(String(keyToken.value))
+                    } else if check(.number) {
+                        let keyToken = try consume(
+                            .number,
+                            message: "Expected number for object key."
+                        )
+                        let raw = String(keyToken.value)
+                        guard !raw.contains("."), let intKey = Int(raw) else {
+                            throw JinjaError.parser(
+                                "Expected integer for numeric object key. Got \(raw) instead"
+                            )
+                        }
+                        key = .int(intKey)
                     } else {
                         throw JinjaError.parser(
-                            "Expected string literal or identifier for object key. Got \(peek().kind) instead"
+                            "Expected string literal, identifier, or integer for object key. Got \(peek().kind) instead"
                         )
                     }
                     try consume(.colon, message: "Expected ':' after object key.")
                     let value = try parseExpression()
-                    pairs[String(keyToken.value)] = value
+                    pairs[key] = value
                     if !check(.closeBrace) && !match(.comma) {
                         break
                     }

--- a/Sources/Jinja/PropertyMembers.swift
+++ b/Sources/Jinja/PropertyMembers.swift
@@ -148,7 +148,7 @@ public enum PropertyMembers {
     // MARK: - Object Properties
 
     private static func evaluateObjectProperty(
-        _ obj: OrderedDictionary<String, Value>,
+        _ obj: OrderedDictionary<ObjectKey, Value>,
         _ propertyName: String
     ) throws -> Value {
         switch propertyName {
@@ -158,7 +158,7 @@ public enum PropertyMembers {
                 kwargs,
                 _ in
                 _ = try resolveCallArguments(args: args, kwargs: kwargs, parameters: [])
-                let pairs = obj.map { key, value in Value.array([.string(key), value]) }
+                let pairs = obj.map { key, value in Value.array([Value(key), value]) }
                 return .array(pairs)
             }
             return .function(fn)
@@ -178,15 +178,10 @@ public enum PropertyMembers {
                     throw JinjaError.runtime("get() requires a 'key' argument")
                 }
 
-                let key: String
-                switch keyValue {
-                case let .string(s):
-                    key = s
-                default:
-                    key = keyValue.description
-                }
-
                 let defaultValue = arguments["default"] ?? .null
+                guard let key = ObjectKey(keyValue) else {
+                    return defaultValue
+                }
                 return obj[key] ?? defaultValue
             }
             return .function(fn)
@@ -196,7 +191,7 @@ public enum PropertyMembers {
                 kwargs,
                 _ in
                 _ = try resolveCallArguments(args: args, kwargs: kwargs, parameters: [])
-                let keys = obj.keys.map { Value.string($0) }
+                let keys = obj.keys.map(Value.init)
                 return .array(keys)
             }
             return .function(fn)
@@ -210,7 +205,7 @@ public enum PropertyMembers {
             }
             return .function(fn)
         default:
-            return obj[propertyName] ?? .undefined
+            return obj[.string(propertyName)] ?? .undefined
         }
     }
 }

--- a/Sources/Jinja/Tests.swift
+++ b/Sources/Jinja/Tests.swift
@@ -558,7 +558,7 @@ public enum Tests {
             }
             return false
         case let .object(dict):
-            if case let .string(key) = input {
+            if let key = ObjectKey(input) {
                 return dict[key] != nil
             }
             return false

--- a/Sources/Jinja/Value.swift
+++ b/Sources/Jinja/Value.swift
@@ -21,7 +21,7 @@ public enum Value: Sendable {
     /// Array containing ordered collection of values.
     case array([Value])
     /// Object containing key-value pairs with preserved insertion order.
-    case object(OrderedDictionary<String, Value>)
+    case object(OrderedDictionary<ObjectKey, Value>)
     /// Function value that can be called with arguments.
     case function(@Sendable ([Value], [String: Value], Environment) throws -> Value)
     /// Macro value that can be invoked with arguments.
@@ -54,9 +54,9 @@ public enum Value: Sendable {
             let values = try array.map { try Value(any: $0) }
             self = .array(values)
         case let dict as [String: Any?]:
-            var orderedDict = OrderedDictionary<String, Value>()
+            var orderedDict = OrderedDictionary<ObjectKey, Value>()
             for (key, value) in dict.sorted(by: { $0.key < $1.key }) {
-                orderedDict[key] = try Value(any: value)
+                orderedDict[.string(key)] = try Value(any: value)
             }
             self = .object(orderedDict)
         case let macro as Macro:
@@ -65,6 +65,18 @@ public enum Value: Sendable {
             throw JinjaError.runtime(
                 "Cannot convert value of type \(type(of: value)) to Jinja Value"
             )
+        }
+    }
+
+    /// Creates a value from an object key.
+    ///
+    /// - Parameter key: The object key to convert
+    public init(_ key: ObjectKey) {
+        switch key {
+        case let .string(string):
+            self = .string(string)
+        case let .int(int):
+            self = .int(int)
         }
     }
 
@@ -369,7 +381,7 @@ public enum Value: Sendable {
             guard !substr.isEmpty else { return true }  // '' in 'abc' -> true
             return str.contains(substr)
         case let .object(dict):
-            guard case let .string(key) = self else { return false }
+            guard let key = ObjectKey(self) else { return false }
             return dict.keys.contains(key)
 
         default:
@@ -449,7 +461,7 @@ extension Value: CustomStringConvertible {
             }
             return "[\(elements.joined(separator: ", "))]"
         case .object(let o):
-            return "{\(o.map { "\($0.key): \($0.value.description)" }.joined(separator: ", "))}"
+            return "{\(o.map { "\($0.key.description): \($0.value.description)" }.joined(separator: ", "))}"
         case .function: return "[Function]"
         case .macro(let m): return "[Macro \(m.name)]"
         }
@@ -500,30 +512,13 @@ extension Value: Hashable {
 // MARK: - Encodable
 
 extension Value: Encodable {
-    private struct DynamicCodingKey: CodingKey {
-        var stringValue: String
-        var intValue: Int? { nil }
-
-        init?(stringValue: String) {
-            self.stringValue = stringValue
-        }
-
-        init?(intValue: Int) {
-            return nil
-        }
-    }
-
     public func encode(to encoder: Encoder) throws {
         switch self {
         case let .object(value):
-            var keyedContainer = encoder.container(keyedBy: DynamicCodingKey.self)
+            var keyedContainer = encoder.container(keyedBy: ObjectKey.self)
             for key in value.keys.sorted() {
-                guard let codingKey = DynamicCodingKey(stringValue: key),
-                    let encodedValue = value[key]
-                else {
-                    continue
-                }
-                try keyedContainer.encode(encodedValue, forKey: codingKey)
+                guard let encodedValue = value[key] else { continue }
+                try keyedContainer.encode(encodedValue, forKey: key)
             }
         case let .string(value):
             var container = encoder.singleValueContainer()
@@ -579,9 +574,9 @@ extension Value: Decodable {
         } else if let value = try? container.decode([Value].self) {
             self = .array(value)
         } else if let value = try? container.decode([String: Value].self) {
-            var orderedDictionary: OrderedDictionary<String, Value> = [:]
-            for (key) in value.keys.sorted() {
-                orderedDictionary[key] = value[key]
+            var orderedDictionary: OrderedDictionary<ObjectKey, Value> = [:]
+            for key in value.keys.sorted() {
+                orderedDictionary[.string(key)] = value[key]
             }
             self = .object(orderedDictionary)
         } else if let macro = try? container.decode(Macro.self) {
@@ -650,11 +645,158 @@ extension Value: ExpressibleByArrayLiteral {
 // MARK: - ExpressibleByDictionaryLiteral
 
 extension Value: ExpressibleByDictionaryLiteral {
-    public init(dictionaryLiteral elements: (String, Value)...) {
-        var dict = OrderedDictionary<String, Value>()
+    public init(dictionaryLiteral elements: (ObjectKey, Value)...) {
+        var dict = OrderedDictionary<ObjectKey, Value>()
         for (key, value) in elements {
             dict[key] = value
         }
         self = .object(dict)
+    }
+}
+
+// MARK: - ObjectKey
+
+/// A key in a Jinja object (dictionary) value.
+///
+/// Jinja object literals accept string keys (quoted or bare identifiers) and integer keys.
+/// Integer keys are distinct from their string representations:
+/// `{512: "b"}[512]` succeeds while `{512: "b"}["512"]` does not.
+public enum ObjectKey: Hashable, Sendable {
+    /// A string key, from a quoted literal or bare identifier.
+    case string(String)
+    /// An integer key, from a numeric literal.
+    case int(Int)
+
+    /// Creates an object key from a runtime value.
+    ///
+    /// - Parameter value: A string or integer value to use as a key.
+    /// - Returns: The corresponding key, or `nil` if the value is not a valid key type.
+    public init?(_ value: Value) {
+        switch value {
+        case let .string(string):
+            self = .string(string)
+        case let .int(int):
+            self = .int(int)
+        default:
+            return nil
+        }
+    }
+
+    /// Compares this key to another key.
+    ///
+    /// Integer keys compare numerically and sort before string keys.
+    /// String keys compare lexicographically using the given options.
+    ///
+    /// - Parameters:
+    ///   - other: The key to compare against.
+    ///   - options: Options for string comparisons, such as `.caseInsensitive`.
+    /// - Returns: The ordering of this key relative to `other`.
+    public func compare(
+        _ other: ObjectKey,
+        options: String.CompareOptions = []
+    ) -> ComparisonResult {
+        switch (self, other) {
+        case let (.int(a), .int(b)):
+            if a < b { return .orderedAscending }
+            if a > b { return .orderedDescending }
+            return .orderedSame
+        case let (.string(a), .string(b)):
+            return a.compare(b, options: options)
+        case (.int, .string):
+            return .orderedAscending
+        case (.string, .int):
+            return .orderedDescending
+        }
+    }
+}
+
+// MARK: Comparable
+
+extension ObjectKey: Comparable {
+    public static func < (lhs: ObjectKey, rhs: ObjectKey) -> Bool {
+        lhs.compare(rhs) == .orderedAscending
+    }
+}
+
+// MARK: CustomStringConvertible
+
+extension ObjectKey: CustomStringConvertible {
+    public var description: String {
+        stringValue
+    }
+}
+
+// MARK: CodingKey
+
+extension ObjectKey: CodingKey {
+    /// The string representation of the key.
+    public var stringValue: String {
+        switch self {
+        case let .string(string):
+            return string
+        case let .int(int):
+            return String(int)
+        }
+    }
+
+    /// The integer value of the key, or `nil` for string keys.
+    public var intValue: Int? {
+        guard case let .int(int) = self else { return nil }
+        return int
+    }
+
+    public init(stringValue: String) {
+        self = .string(stringValue)
+    }
+
+    public init(intValue: Int) {
+        self = .int(intValue)
+    }
+}
+
+// MARK: ExpressibleByStringLiteral
+
+extension ObjectKey: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+// MARK: ExpressibleByIntegerLiteral
+
+extension ObjectKey: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self = .int(value)
+    }
+}
+
+// MARK: Codable
+
+extension ObjectKey: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let int = try? container.decode(Int.self) {
+            self = .int(int)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else {
+            throw DecodingError.typeMismatch(
+                ObjectKey.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "ObjectKey must be a string or integer"
+                )
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .string(string):
+            try container.encode(string)
+        case let .int(int):
+            try container.encode(int)
+        }
     }
 }

--- a/Sources/Jinja/Value.swift
+++ b/Sources/Jinja/Value.swift
@@ -516,8 +516,20 @@ extension Value: Encodable {
         switch self {
         case let .object(value):
             var keyedContainer = encoder.container(keyedBy: ObjectKey.self)
+            var seenStringValues: Set<String> = []
             for key in value.keys.sorted() {
                 guard let encodedValue = value[key] else { continue }
+                let stringKey = key.stringValue
+                guard seenStringValues.insert(stringKey).inserted else {
+                    throw EncodingError.invalidValue(
+                        self,
+                        EncodingError.Context(
+                            codingPath: encoder.codingPath,
+                            debugDescription:
+                                "Cannot encode object with colliding keys that both serialize to \"\(stringKey)\""
+                        )
+                    )
+                }
                 try keyedContainer.encode(encodedValue, forKey: key)
             }
         case let .string(value):
@@ -745,11 +757,11 @@ extension ObjectKey: CodingKey {
         return int
     }
 
-    public init(stringValue: String) {
+    public init?(stringValue: String) {
         self = .string(stringValue)
     }
 
-    public init(intValue: Int) {
+    public init?(intValue: Int) {
         self = .int(intValue)
     }
 }

--- a/Sources/Jinja/Value.swift
+++ b/Sources/Jinja/Value.swift
@@ -734,7 +734,12 @@ extension ObjectKey: Comparable {
 
 extension ObjectKey: CustomStringConvertible {
     public var description: String {
-        stringValue
+        switch self {
+        case let .string(string):
+            return "'\(string)'"
+        case let .int(int):
+            return String(int)
+        }
     }
 }
 

--- a/Tests/JinjaTests/FiltersTests.swift
+++ b/Tests/JinjaTests/FiltersTests.swift
@@ -345,6 +345,22 @@ struct FiltersTests {
         #expect(result == expected)
     }
 
+    @Test("dictsort filter with integer keys")
+    func dictsortFilterWithIntegerKeys() throws {
+        let dict = Value.object([
+            1024: .int(256),
+            0: .int(0),
+            512: .int(128),
+        ])
+        let result = try Filters.dictsort([dict], kwargs: [:], env: env)
+        let expected = Value.array([
+            .array([.int(0), .int(0)]),
+            .array([.int(512), .int(128)]),
+            .array([.int(1024), .int(256)]),
+        ])
+        #expect(result == expected)
+    }
+
     @Test("dictsort filter with reverse")
     func dictsortFilterWithReverse() throws {
         let dict = Value.object(["b": .int(2), "a": .int(1)])

--- a/Tests/JinjaTests/PropertyMembersTests.swift
+++ b/Tests/JinjaTests/PropertyMembersTests.swift
@@ -282,7 +282,7 @@ struct PropertyMembersTests {
 
     @Test("Object items method")
     func objectItems() throws {
-        let dict: OrderedDictionary<String, Value> = ["a": .int(1), "b": .int(2)]
+        let dict: OrderedDictionary<ObjectKey, Value> = ["a": .int(1), "b": .int(2)]
         let value = Value.object(dict)
         let result = try PropertyMembers.evaluate(value, "items")
 
@@ -301,7 +301,7 @@ struct PropertyMembersTests {
 
     @Test("Object get method with existing key")
     func objectGetExisting() throws {
-        let dict: OrderedDictionary<String, Value> = ["name": .string("John"), "age": .int(30)]
+        let dict: OrderedDictionary<ObjectKey, Value> = ["name": .string("John"), "age": .int(30)]
         let value = Value.object(dict)
         let result = try PropertyMembers.evaluate(value, "get")
 
@@ -316,7 +316,7 @@ struct PropertyMembersTests {
 
     @Test("Object get method with missing key")
     func objectGetMissing() throws {
-        let dict: OrderedDictionary<String, Value> = ["name": .string("John")]
+        let dict: OrderedDictionary<ObjectKey, Value> = ["name": .string("John")]
         let value = Value.object(dict)
         let result = try PropertyMembers.evaluate(value, "get")
 
@@ -331,7 +331,7 @@ struct PropertyMembersTests {
 
     @Test("Object get method with default value")
     func objectGetWithDefault() throws {
-        let dict: OrderedDictionary<String, Value> = ["name": .string("John")]
+        let dict: OrderedDictionary<ObjectKey, Value> = ["name": .string("John")]
         let value = Value.object(dict)
         let result = try PropertyMembers.evaluate(value, "get")
 
@@ -344,9 +344,9 @@ struct PropertyMembersTests {
         #expect(getResult == .string("default"))
     }
 
-    @Test("Object get method with non-string key")
-    func objectGetNonStringKey() throws {
-        let dict: OrderedDictionary<String, Value> = ["42": .string("answer")]
+    @Test("Object get method with integer key")
+    func objectGetIntegerKey() throws {
+        let dict: OrderedDictionary<ObjectKey, Value> = [42: .string("answer")]
         let value = Value.object(dict)
         let result = try PropertyMembers.evaluate(value, "get")
 
@@ -357,11 +357,15 @@ struct PropertyMembersTests {
 
         let getResult = try fn([.int(42)], [:], Environment())
         #expect(getResult == .string("answer"))
+
+        // Integer keys are distinct from their string representations.
+        let missing = try fn([.string("42")], [:], Environment())
+        #expect(missing == .null)
     }
 
     @Test("Object keys method")
     func objectKeys() throws {
-        let dict: OrderedDictionary<String, Value> = ["a": .int(1), "b": .int(2), "c": .int(3)]
+        let dict: OrderedDictionary<ObjectKey, Value> = ["a": .int(1), "b": .int(2), "c": .int(3)]
         let value = Value.object(dict)
         let result = try PropertyMembers.evaluate(value, "keys")
 
@@ -377,7 +381,7 @@ struct PropertyMembersTests {
 
     @Test("Object values method")
     func objectValues() throws {
-        let dict: OrderedDictionary<String, Value> = ["a": .int(1), "b": .int(2), "c": .int(3)]
+        let dict: OrderedDictionary<ObjectKey, Value> = ["a": .int(1), "b": .int(2), "c": .int(3)]
         let value = Value.object(dict)
         let result = try PropertyMembers.evaluate(value, "values")
 
@@ -393,7 +397,7 @@ struct PropertyMembersTests {
 
     @Test("Object direct property access")
     func objectDirectProperty() throws {
-        let dict: OrderedDictionary<String, Value> = ["foo": .string("bar")]
+        let dict: OrderedDictionary<ObjectKey, Value> = ["foo": .string("bar")]
         let value = Value.object(dict)
         let result = try PropertyMembers.evaluate(value, "foo")
         #expect(result == .string("bar"))
@@ -401,7 +405,7 @@ struct PropertyMembersTests {
 
     @Test("Object undefined property")
     func objectUndefinedProperty() throws {
-        let dict: OrderedDictionary<String, Value> = ["foo": .string("bar")]
+        let dict: OrderedDictionary<ObjectKey, Value> = ["foo": .string("bar")]
         let value = Value.object(dict)
         let result = try PropertyMembers.evaluate(value, "nonexistent")
         #expect(result == .undefined)
@@ -434,7 +438,7 @@ struct PropertyMembersTests {
 
     @Test("Object get with no key argument throws")
     func objectGetNoKey() throws {
-        let dict: OrderedDictionary<String, Value> = ["a": .int(1)]
+        let dict: OrderedDictionary<ObjectKey, Value> = ["a": .int(1)]
         let value = Value.object(dict)
         let result = try PropertyMembers.evaluate(value, "get")
 

--- a/Tests/JinjaTests/TemplateTests.swift
+++ b/Tests/JinjaTests/TemplateTests.swift
@@ -1554,6 +1554,45 @@ struct TemplateTests {
         #expect(rendered == "value")
     }
 
+    @Test("Object literals with integer keys")
+    func objectLiteralsWithIntegerKeys() throws {
+        let string = #"{% set d = {0: "a", 512: "b"} %}{{ d[512] }}"#
+        let rendered = try Template(string).render([:])
+        #expect(rendered == "b")
+    }
+
+    @Test("Object literals with integer keys sort numerically")
+    func objectLiteralsIntegerKeysDictsort() throws {
+        let string = #"""
+            {%- set budget_reflections = {
+                 0:      0,
+                 512:    128,
+                 1024:   256,
+                 2048:   512,
+                 4096:   512,
+                 8192:   1024,
+                 16384:  1024
+            } -%}
+            {%- set thinking_budget = 1000 -%}
+            {%- set ns = namespace(chosen=none) -%}
+            {%- for budget, reflection in budget_reflections|dictsort -%}
+              {%- if thinking_budget >= budget -%}
+                {%- set ns.chosen = reflection -%}
+              {%- endif -%}
+            {%- endfor -%}
+            {{ ns.chosen }}
+            """#
+        let rendered = try Template(string).render([:])
+        #expect(rendered == "128")
+    }
+
+    @Test("Integer object keys remain distinct from string keys")
+    func integerObjectKeysDistinctFromStrings() throws {
+        let string = #"{% set d = {512: "int"} %}{{ d[512] }}|{{ d['512'] is undefined }}"#
+        let rendered = try Template(string).render([:])
+        #expect(rendered == "int|true")
+    }
+
     @Test("Object literals nested")
     func objectLiteralsNested() throws {
         // Test simple object with minimal spacing

--- a/Tests/JinjaTests/ValueTests.swift
+++ b/Tests/JinjaTests/ValueTests.swift
@@ -194,6 +194,14 @@ struct ValueTests {
         #expect(throws: EncodingError.self) {
             _ = try encoder.encode(functionValue)
         }
+
+        // Integer and string keys that share a stringValue must not silently collide
+        var collidingKeys = OrderedDictionary<ObjectKey, Value>()
+        collidingKeys[.int(512)] = Value.string("int")
+        collidingKeys[.string("512")] = Value.string("str")
+        #expect(throws: EncodingError.self) {
+            _ = try encoder.encode(Value.object(collidingKeys))
+        }
     }
 
     @Test("Decodable conformance")

--- a/Tests/JinjaTests/ValueTests.swift
+++ b/Tests/JinjaTests/ValueTests.swift
@@ -108,7 +108,12 @@ struct ValueTests {
         #expect(Value.null.description == "")
         #expect(Value.undefined.description == "")
         #expect(Value.array([Value.int(1), Value.int(2)]).description == "[1, 2]")
-        #expect(Value.object(["a": Value.int(1)]).description == "{a: 1}")
+        #expect(Value.object(["a": Value.int(1)]).description == "{'a': 1}")
+
+        var collidingKeys = OrderedDictionary<ObjectKey, Value>()
+        collidingKeys[.int(512)] = .string("int")
+        collidingKeys[.string("512")] = .string("str")
+        #expect(Value.object(collidingKeys).description == "{512: int, '512': str}")
     }
 
     @Test("isTruthy behavior")

--- a/Tests/JinjaTests/ValueTests.swift
+++ b/Tests/JinjaTests/ValueTests.swift
@@ -165,7 +165,7 @@ struct ValueTests {
         #expect(arrayJSON == "[1,\"test\",false]")
 
         // Test object encoding
-        var objectDict = OrderedDictionary<String, Value>()
+        var objectDict = OrderedDictionary<ObjectKey, Value>()
         objectDict["name"] = Value.string("John")
         objectDict["age"] = Value.int(30)
         objectDict["active"] = Value.boolean(true)
@@ -298,7 +298,7 @@ struct ValueTests {
         let decoder = JSONDecoder()
 
         // Create a complex nested structure
-        var complexDict = OrderedDictionary<String, Value>()
+        var complexDict = OrderedDictionary<ObjectKey, Value>()
         complexDict["users"] = Value.array([
             Value.object([
                 "id": Value.int(1),
@@ -392,7 +392,7 @@ struct ValueTests {
         #expect(decodedMixedArray == mixedArray)
 
         // Test objects with various key types (all should be strings in JSON)
-        var objectWithVariousKeys = OrderedDictionary<String, Value>()
+        var objectWithVariousKeys = OrderedDictionary<ObjectKey, Value>()
         objectWithVariousKeys["stringKey"] = Value.string("stringValue")
         objectWithVariousKeys["numberKey"] = Value.double(123.45)
         objectWithVariousKeys["booleanKey"] = Value.boolean(false)


### PR DESCRIPTION
Fixes #62 

Add an `ObjectKey` type unifying string and integer dictionary keys across the parser, interpreter, and value model, so templates can write `{0: "a", 512: "b"}` and integer keys stay distinct from their string representations.