### PR TITLE
Restore source compatibility for String-keyed `Value.object`

### DIFF
--- a/Sources/Jinja/Value.swift
+++ b/Sources/Jinja/Value.swift
@@ -82,6 +82,41 @@ public enum Value: Sendable {
         }
     }
 
+    /// Creates an object value from a dictionary keyed by strings.
+    ///
+    /// This is a source-compatibility affordance for callers written against versions of the
+    /// library where object values were keyed by `String` rather than ``ObjectKey``. Each key is
+    /// wrapped as ``ObjectKey/string(_:)`` while preserving the dictionary's insertion order.
+    ///
+    /// - Parameter dictionary: The string-keyed key-value pairs to store, in order.
+    /// - Returns: An object value with the equivalent ``ObjectKey``-keyed storage.
+    @_disfavoredOverload
+    public static func object(_ dictionary: OrderedDictionary<String, Value>) -> Value {
+        var storage = OrderedDictionary<ObjectKey, Value>(minimumCapacity: dictionary.count)
+        for (key, value) in dictionary {
+            storage[.string(key)] = value
+        }
+        return .object(storage)
+    }
+
+    /// Creates an object value from a dictionary keyed by strings.
+    ///
+    /// This is a source-compatibility affordance for callers written against versions of the
+    /// library where object values were keyed by `String` rather than ``ObjectKey``. Each key is
+    /// wrapped as ``ObjectKey/string(_:)``, and keys are stored in sorted order for deterministic
+    /// output, matching ``init(any:)``.
+    ///
+    /// - Parameter dictionary: The string-keyed key-value pairs to store.
+    /// - Returns: An object value with the equivalent ``ObjectKey``-keyed storage.
+    @_disfavoredOverload
+    public static func object(_ dictionary: [String: Value]) -> Value {
+        var storage = OrderedDictionary<ObjectKey, Value>(minimumCapacity: dictionary.count)
+        for key in dictionary.keys.sorted() {
+            storage[.string(key)] = dictionary[key]
+        }
+        return .object(storage)
+    }
+
     /// Creates a value from an object key.
     ///
     /// - Parameter key: The object key to convert
@@ -671,10 +706,16 @@ extension Value: ExpressibleByArrayLiteral {
 // MARK: - ExpressibleByDictionaryLiteral
 
 extension Value: ExpressibleByDictionaryLiteral {
-    public init(dictionaryLiteral elements: (ObjectKey, Value)...) {
-        var dict = OrderedDictionary<ObjectKey, Value>()
+    /// Creates an object value from a dictionary literal.
+    ///
+    /// Keys use `String` (rather than ``ObjectKey``) so that dictionary literals with dynamic
+    /// string keys, such as `[someString: value]`, remain source compatible. Each key is stored
+    /// as ``ObjectKey/string(_:)``. To create an object with integer keys, use ``object(_:)-swift.type.method``
+    /// with an explicitly ``ObjectKey``-keyed dictionary.
+    public init(dictionaryLiteral elements: (String, Value)...) {
+        var dict = OrderedDictionary<ObjectKey, Value>(minimumCapacity: elements.count)
         for (key, value) in elements {
-            dict[key] = value
+            dict[.string(key)] = value
         }
         self = .object(dict)
     }
@@ -798,6 +839,23 @@ extension ObjectKey: ExpressibleByStringLiteral {
 extension ObjectKey: ExpressibleByIntegerLiteral {
     public init(integerLiteral value: Int) {
         self = .int(value)
+    }
+}
+
+// MARK: - Object storage affordances
+
+extension OrderedDictionary where Key == ObjectKey, Value == Jinja.Value {
+    /// Accesses the value associated with a string key.
+    ///
+    /// This is a source-compatibility affordance for callers written against versions of the
+    /// library where object values were keyed by `String`. It is equivalent to subscripting with
+    /// ``ObjectKey/string(_:)``, so it only matches string keys and never integer keys.
+    ///
+    /// - Parameter key: The string key to look up, wrapped as ``ObjectKey/string(_:)``.
+    @_disfavoredOverload
+    public subscript(key: String) -> Jinja.Value? {
+        get { self[.string(key)] }
+        set { self[.string(key)] = newValue }
     }
 }
 

--- a/Tests/JinjaTests/ValueTests.swift
+++ b/Tests/JinjaTests/ValueTests.swift
@@ -104,6 +104,69 @@ struct ValueTests {
         #expect(nilValue == Value.null)
     }
 
+    @Test("object(_:) from String-keyed OrderedDictionary preserves order")
+    func objectFromStringKeyedOrderedDictionary() {
+        var source = OrderedDictionary<String, Value>()
+        source["z"] = .int(1)
+        source["a"] = .int(2)
+
+        let value = Value.object(source)
+        guard case let .object(dict) = value else {
+            Issue.record("Expected object value")
+            return
+        }
+        // Keys are wrapped as .string and insertion order is preserved.
+        #expect(Array(dict.keys) == [.string("z"), .string("a")])
+        #expect(dict[.string("z")] == .int(1))
+        #expect(dict[.string("a")] == .int(2))
+    }
+
+    @Test("object(_:) from String-keyed Dictionary sorts keys")
+    func objectFromStringKeyedDictionary() {
+        let source: [String: Value] = ["z": .int(1), "a": .int(2), "m": .int(3)]
+
+        let value = Value.object(source)
+        guard case let .object(dict) = value else {
+            Issue.record("Expected object value")
+            return
+        }
+        #expect(Array(dict.keys) == [.string("a"), .string("m"), .string("z")])
+    }
+
+    @Test("object(_:) via init(uniqueKeysWithValues:) stays source-compatible")
+    func objectFromUniqueKeysWithValues() {
+        // Mirrors how downstream code built String-keyed objects before ObjectKey.
+        var result: [String: Value] = [:]
+        result["role"] = .string("user")
+        let value = Value.object(.init(uniqueKeysWithValues: result))
+        #expect(value == ["role": .string("user")])
+    }
+
+    @Test("Dictionary literal accepts dynamic String keys")
+    func dictionaryLiteralWithDynamicStringKey() {
+        // A non-literal String key would fail if the literal required ObjectKey keys.
+        let key = String("role")
+        let value: Value = [key: .string("user")]
+        guard case let .object(dict) = value else {
+            Issue.record("Expected object value")
+            return
+        }
+        #expect(dict[.string("role")] == .string("user"))
+    }
+
+    @Test("String subscript reads and writes object storage")
+    func objectStorageStringSubscript() {
+        var dict = OrderedDictionary<ObjectKey, Value>()
+        let dynamicKey = "count"
+        dict[dynamicKey] = .int(7)
+
+        #expect(dict[dynamicKey] == .int(7))
+        #expect(dict[.string("count")] == .int(7))
+        // The string subscript never matches integer keys.
+        dict[.int(512)] = .string("int")
+        #expect(dict["512"] == nil)
+    }
+
     @Test("Dictionary conversion via any is key-sorted")
     func initFromAnyDictionarySortsKeys() throws {
         let source: [String: Any?] = [


### PR DESCRIPTION
Follow-up to #62 

The integer-key fix changed `Value.object`'s key type from `String` to `ObjectKey`, breaking downstream callers that construct objects from `String`-keyed dictionaries.

Add disfavored `object(_:)` overloads for `OrderedDictionary<String, Value>` and `[String: Value]`, a `String` subscript on `ObjectKey`-keyed object storage, and revert the dictionary literal conformance to `String` keys so literals with dynamic `String` keys keep compiling. Template integer keys are unaffected since the parser builds `ObjectKey` storage directly.