### PR TITLE
Coerce upper/lower input to string (like Jinja2) instead of throwing on non-strings

### DIFF
--- a/Sources/Jinja/Filters.swift
+++ b/Sources/Jinja/Filters.swift
@@ -3,8 +3,9 @@ import Foundation
 /// Built-in filters for Jinja template rendering.
 ///
 /// Filters transform values in template expressions using the pipe syntax (`|`).
-/// All filter functions follow the same signature pattern, accepting an array of values
-/// (with the filtered value as the first element), optional keyword arguments, and an environment.
+/// Each filter accepts an array of values (with the filtered value first),
+/// optional keyword arguments,
+/// and an environment.
 public enum Filters {
     // MARK: - Basic String Filters
 
@@ -1103,21 +1104,6 @@ public enum Filters {
         }
     }
 
-    /// Escapes non-ASCII characters in a string as `\uXXXX` sequences.
-    private static func escapeNonASCII(_ string: String) -> String {
-        var result = ""
-        result.reserveCapacity(string.utf16.count)
-        // Iterate UTF-16 code units so non-BMP scalars emit surrogate pairs.
-        for codeUnit in string.utf16 {
-            if codeUnit > 127 {
-                result += String(format: "\\u%04x", codeUnit)
-            } else if let scalar = UnicodeScalar(codeUnit) {
-                result.append(Character(scalar))
-            }
-        }
-        return result
-    }
-
     /// Returns absolute value of a number.
     @Sendable public static func abs(
         _ args: [Value],
@@ -2074,6 +2060,51 @@ private func softString(_ value: Value?) -> String {
     (value ?? .undefined).description
 }
 
+/// Escapes HTML special characters in a string.
+///
+/// Replaces `&`, `<`, `>`, `"`, and `'` with their corresponding HTML entities.
+///
+/// - Parameter string: The string to escape.
+/// - Returns: An HTML-safe copy of `string`.
+private func htmlEscape(_ string: String) -> String {
+    string
+        .replacingOccurrences(of: "&", with: "&amp;")
+        .replacingOccurrences(of: "<", with: "&lt;")
+        .replacingOccurrences(of: ">", with: "&gt;")
+        .replacingOccurrences(of: "\"", with: "&#34;")
+        .replacingOccurrences(of: "'", with: "&#39;")
+}
+
+/// Escapes non-ASCII characters in a string as `\uXXXX` sequences.
+///
+/// Iterates UTF-16 code units so non-BMP scalars emit surrogate pairs.
+///
+/// - Parameter string: The string to escape.
+/// - Returns: An ASCII-only string with non-ASCII characters escaped.
+private func escapeNonASCII(_ string: String) -> String {
+    var result = ""
+    result.reserveCapacity(string.utf16.count)
+    for codeUnit in string.utf16 {
+        if codeUnit > 127 {
+            result += String(format: "\\u%04x", codeUnit)
+        } else if let scalar = UnicodeScalar(codeUnit) {
+            result.append(Character(scalar))
+        }
+    }
+    return result
+}
+
+/// Returns the value of an attribute on an item.
+///
+/// Resolves string attribute names through property members,
+/// and integer indexes into arrays or objects.
+/// Returns `undefined` when the attribute cannot be resolved.
+///
+/// - Parameters:
+///   - item: The value to read from.
+///   - attribute: A string name or integer index identifying the attribute.
+/// - Returns: The attribute value, or `undefined` if it is missing.
+/// - Throws: An error if evaluating a string attribute fails.
 private func resolveAttributeValue(_ item: Value, attribute: Value) throws -> Value {
     switch attribute {
     case let .string(name):
@@ -2095,6 +2126,28 @@ private func resolveAttributeValue(_ item: Value, attribute: Value) throws -> Va
     }
 }
 
+/// Compares two values for ordering.
+///
+/// When both values are strings and comparison is case-insensitive,
+/// or when `useStringComparisonWhenCaseSensitive` is true,
+/// compares their string forms directly.
+/// Otherwise uses ``Value/compare(to:)``,
+/// optionally falling back to description-based ordering on failure.
+///
+/// - Parameters:
+///   - lhs: The left-hand value.
+///   - rhs: The right-hand value.
+///   - caseSensitive: A Boolean value that indicates whether string comparison
+///     is case-sensitive.
+///   - useStringComparisonWhenCaseSensitive: A Boolean value that indicates whether
+///     to compare strings lexicographically even when `caseSensitive` is true.
+///   - fallbackToDescription: A Boolean value that indicates whether to compare
+///     `description` strings when ``Value/compare(to:)`` fails.
+/// - Returns: A negative value if `lhs` precedes `rhs`,
+///   zero if they are equal,
+///   and a positive value if `lhs` follows `rhs`.
+/// - Throws: An error if the values cannot be compared
+///   and `fallbackToDescription` is false.
 private func compareValues(
     _ lhs: Value,
     _ rhs: Value,
@@ -2122,13 +2175,4 @@ private func compareValues(
         }
         throw error
     }
-}
-
-private func htmlEscape(_ string: String) -> String {
-    string
-        .replacingOccurrences(of: "&", with: "&amp;")
-        .replacingOccurrences(of: "<", with: "&lt;")
-        .replacingOccurrences(of: ">", with: "&gt;")
-        .replacingOccurrences(of: "\"", with: "&#34;")
-        .replacingOccurrences(of: "'", with: "&#39;")
 }

--- a/Sources/Jinja/Filters.swift
+++ b/Sources/Jinja/Filters.swift
@@ -21,13 +21,7 @@ public enum Filters {
             defaults: [:]
         )
 
-        // Coerce the input to a string (Jinja2's `soft_str`, which `do_upper` applies) instead
-        // of requiring one: `undefined`/`null` -> "", numbers -> their string form. This matches
-        // interpolation (`Value.description`) and the reference implementations (CPython Jinja2
-        // and llama.cpp's minja), so `x | upper` on a missing/undefined value yields "" rather
-        // than raising - which some chat templates rely on (e.g. `value['type'] | upper`).
-        let str = (args.first ?? .undefined).description
-        return .string(str.uppercased())
+        return .string(softString(args.first).uppercased())
     }
 
     /// Converts a string to lowercase.
@@ -43,11 +37,7 @@ public enum Filters {
             defaults: [:]
         )
 
-        // Coerce the input to a string like `upper` (Jinja2's `soft_str`, applied by `do_lower`):
-        // `undefined`/`null` -> "", numbers -> their string form, matching interpolation and the
-        // CPython Jinja2 / minja reference implementations rather than raising on a non-string.
-        let str = (args.first ?? .undefined).description
-        return .string(str.lowercased())
+        return .string(softString(args.first).lowercased())
     }
 
     /// Returns the length of a string, array, or object.
@@ -94,9 +84,7 @@ public enum Filters {
             defaults: ["separator": .string(""), "attribute": .null]
         )
 
-        guard case let .string(separator) = arguments["separator"] else {
-            throw JinjaError.runtime("join filter requires string separator")
-        }
+        let separator = softString(arguments["separator"])
 
         let strings: [String]
         if let attribute = arguments["attribute"], attribute != .null {
@@ -764,10 +752,6 @@ public enum Filters {
         kwargs: [String: Value] = [:],
         env: Environment
     ) throws -> Value {
-        guard args.count > 1, case let .string(formatString) = args[0] else {
-            return args.first ?? .string("")
-        }
-
         _ = try resolveCallArguments(
             args: Array(args.dropFirst()),
             kwargs: kwargs,
@@ -775,7 +759,12 @@ public enum Filters {
             defaults: [:]
         )
 
+        let formatString = softString(args.first)
         let formatArgs = Array(args.dropFirst())
+        guard !formatArgs.isEmpty else {
+            return .string(formatString)
+        }
+
         var result = ""
         var formatIdx = formatString.startIndex
         var argIdx = 0
@@ -1030,16 +1019,14 @@ public enum Filters {
         kwargs: [String: Value] = [:],
         env: Environment
     ) throws -> Value {
-        guard case let .string(str) = args.first else {
-            return .string("")
-        }
-
         let arguments = try resolveCallArguments(
             args: Array(args.dropFirst()),
             kwargs: kwargs,
             parameters: ["chars"],
             defaults: ["chars": .null]
         )
+
+        let str = softString(args.first)
 
         let characterSet: CharacterSet
         if case let .string(chars) = arguments["chars"], !chars.isEmpty {
@@ -1164,10 +1151,6 @@ public enum Filters {
         kwargs: [String: Value] = [:],
         env: Environment
     ) throws -> Value {
-        guard case let .string(str) = args.first else {
-            return .string("")
-        }
-
         _ = try resolveCallArguments(
             args: Array(args.dropFirst()),
             kwargs: kwargs,
@@ -1175,6 +1158,7 @@ public enum Filters {
             defaults: [:]
         )
 
+        let str = softString(args.first)
         return .string(str.prefix(1).uppercased() + str.dropFirst().lowercased())
     }
 
@@ -1184,10 +1168,6 @@ public enum Filters {
         kwargs: [String: Value] = [:],
         env: Environment
     ) throws -> Value {
-        guard case let .string(str) = args.first else {
-            return args.first ?? .string("")
-        }
-
         let arguments = try resolveCallArguments(
             args: Array(args.dropFirst()),
             kwargs: kwargs,
@@ -1199,6 +1179,7 @@ public enum Filters {
             throw JinjaError.runtime("center filter requires width parameter")
         }
 
+        let str = softString(args.first)
         let padCount = width - str.count
         if padCount <= 0 {
             return .string(str)
@@ -1452,10 +1433,6 @@ public enum Filters {
         kwargs: [String: Value] = [:],
         env: Environment
     ) throws -> Value {
-        guard case let .string(str) = args.first else {
-            return .string("")
-        }
-
         _ = try resolveCallArguments(
             args: Array(args.dropFirst()),
             kwargs: kwargs,
@@ -1463,7 +1440,7 @@ public enum Filters {
             defaults: [:]
         )
 
-        return .string(str.capitalized)
+        return .string(softString(args.first).capitalized)
     }
 
     /// Counts words in a string.
@@ -1472,10 +1449,6 @@ public enum Filters {
         kwargs: [String: Value] = [:],
         env: Environment
     ) throws -> Value {
-        guard case let .string(str) = args.first else {
-            return .int(0)
-        }
-
         _ = try resolveCallArguments(
             args: Array(args.dropFirst()),
             kwargs: kwargs,
@@ -1483,7 +1456,7 @@ public enum Filters {
             defaults: [:]
         )
 
-        let words = str.split { $0.isWhitespace || $0.isNewline }
+        let words = softString(args.first).split { $0.isWhitespace || $0.isNewline }
         return .int(words.count)
     }
 
@@ -1497,10 +1470,6 @@ public enum Filters {
         kwargs: [String: Value] = [:],
         env: Environment
     ) throws -> Value {
-        guard case let .string(str) = args.first else {
-            return args.first ?? .string("")
-        }
-
         let arguments = try resolveCallArguments(
             args: Array(args.dropFirst()),
             kwargs: kwargs,
@@ -1508,11 +1477,9 @@ public enum Filters {
             defaults: ["count": .null]
         )
 
-        guard case let .string(old) = arguments["old"],
-            case let .string(new) = arguments["new"]
-        else {
-            throw JinjaError.runtime("replace() requires 'old' and 'new' string arguments.")
-        }
+        let str = softString(args.first)
+        let old = softString(arguments["old"])
+        let new = softString(arguments["new"])
 
         // Handle count parameter - can be positional (3rd arg) or named (count=)
         let count: Int?
@@ -2092,6 +2059,20 @@ public enum Filters {
 }
 
 // MARK: -
+
+/// Returns the string form of a value, matching Jinja2's `soft_str`.
+///
+/// Treats `undefined` and `null` as an empty string.
+/// Other values use the same representation as template interpolation
+/// (`Value.description`).
+/// String filters call this instead of requiring a `.string` case,
+/// so expressions like `value['type'] | upper` succeed when the value is missing.
+///
+/// - Parameter value: The value to convert, or `nil` to treat as undefined.
+/// - Returns: A string suitable for string filters that accept non-string input.
+private func softString(_ value: Value?) -> String {
+    (value ?? .undefined).description
+}
 
 private func resolveAttributeValue(_ item: Value, attribute: Value) throws -> Value {
     switch attribute {

--- a/Sources/Jinja/Filters.swift
+++ b/Sources/Jinja/Filters.swift
@@ -14,10 +14,6 @@ public enum Filters {
         kwargs: [String: Value] = [:],
         env: Environment
     ) throws -> Value {
-        guard case let .string(str) = args.first else {
-            throw JinjaError.runtime("upper filter requires string")
-        }
-
         _ = try resolveCallArguments(
             args: Array(args.dropFirst()),
             kwargs: kwargs,
@@ -25,6 +21,12 @@ public enum Filters {
             defaults: [:]
         )
 
+        // Coerce the input to a string (Jinja2's `soft_str`, which `do_upper` applies) instead
+        // of requiring one: `undefined`/`null` -> "", numbers -> their string form. This matches
+        // interpolation (`Value.description`) and the reference implementations (CPython Jinja2
+        // and llama.cpp's minja), so `x | upper` on a missing/undefined value yields "" rather
+        // than raising - which some chat templates rely on (e.g. `value['type'] | upper`).
+        let str = (args.first ?? .undefined).description
         return .string(str.uppercased())
     }
 
@@ -34,10 +36,6 @@ public enum Filters {
         kwargs: [String: Value] = [:],
         env: Environment
     ) throws -> Value {
-        guard case let .string(str) = args.first else {
-            throw JinjaError.runtime("lower filter requires string")
-        }
-
         _ = try resolveCallArguments(
             args: Array(args.dropFirst()),
             kwargs: kwargs,
@@ -45,6 +43,10 @@ public enum Filters {
             defaults: [:]
         )
 
+        // Coerce the input to a string like `upper` (Jinja2's `soft_str`, applied by `do_lower`):
+        // `undefined`/`null` -> "", numbers -> their string form, matching interpolation and the
+        // CPython Jinja2 / minja reference implementations rather than raising on a non-string.
+        let str = (args.first ?? .undefined).description
         return .string(str.lowercased())
     }
 

--- a/Tests/JinjaTests/FiltersTests.swift
+++ b/Tests/JinjaTests/FiltersTests.swift
@@ -34,8 +34,9 @@ struct FiltersTests {
 
     @Test("upper on an undefined value renders empty instead of raising")
     func upperOnUndefinedRendersEmpty() throws {
-        // Mirrors chat templates that apply `| upper` to a possibly-absent value, e.g. a
-        // JSON-Schema property using anyOf with no scalar `type`: `value['type'] | upper`.
+        // Mirrors chat templates that apply `| upper` to a possibly-absent value.
+        // For example, a JSON Schema property using `anyOf` with no scalar `type`
+        // yields `value['type'] | upper`.
         #expect(try Template("{{ missing | upper }}").render([:]) == "")
     }
 

--- a/Tests/JinjaTests/FiltersTests.swift
+++ b/Tests/JinjaTests/FiltersTests.swift
@@ -19,6 +19,26 @@ struct FiltersTests {
         #expect(result == .string("hello world"))
     }
 
+    @Test("upper filter coerces non-strings (Jinja2 soft_str)")
+    func upperFilterCoercesNonStrings() throws {
+        #expect(try Filters.upper([.undefined], kwargs: [:], env: env) == .string(""))
+        #expect(try Filters.upper([.null], kwargs: [:], env: env) == .string(""))
+        #expect(try Filters.upper([.int(5)], kwargs: [:], env: env) == .string("5"))
+    }
+
+    @Test("lower filter coerces non-strings (Jinja2 soft_str)")
+    func lowerFilterCoercesNonStrings() throws {
+        #expect(try Filters.lower([.undefined], kwargs: [:], env: env) == .string(""))
+        #expect(try Filters.lower([.int(42)], kwargs: [:], env: env) == .string("42"))
+    }
+
+    @Test("upper on an undefined value renders empty instead of raising")
+    func upperOnUndefinedRendersEmpty() throws {
+        // Mirrors chat templates that apply `| upper` to a possibly-absent value, e.g. a
+        // JSON-Schema property using anyOf with no scalar `type`: `value['type'] | upper`.
+        #expect(try Template("{{ missing | upper }}").render([:]) == "")
+    }
+
     @Test("length filter for strings")
     func lengthFilterString() throws {
         let result = try Filters.length([.string("hello")], kwargs: [:], env: env)
@@ -681,18 +701,14 @@ struct FiltersTests {
 
     // MARK: - Error/Edge Case Coverage
 
-    @Test("upper filter with non-string throws")
+    @Test("upper filter coerces a non-string (like Jinja2) rather than throwing")
     func upperFilterNonString() throws {
-        #expect(throws: JinjaError.self) {
-            try Filters.upper([.int(42)], kwargs: [:], env: env)
-        }
+        #expect(try Filters.upper([.int(42)], kwargs: [:], env: env) == .string("42"))
     }
 
-    @Test("lower filter with non-string throws")
+    @Test("lower filter coerces a non-string (like Jinja2) rather than throwing")
     func lowerFilterNonString() throws {
-        #expect(throws: JinjaError.self) {
-            try Filters.lower([.int(42)], kwargs: [:], env: env)
-        }
+        #expect(try Filters.lower([.int(42)], kwargs: [:], env: env) == .string("42"))
     }
 
     @Test("length filter for objects")

--- a/Tests/JinjaTests/FiltersTests.swift
+++ b/Tests/JinjaTests/FiltersTests.swift
@@ -39,6 +39,72 @@ struct FiltersTests {
         #expect(try Template("{{ missing | upper }}").render([:]) == "")
     }
 
+    @Test("capitalize filter coerces non-strings (Jinja2 soft_str)")
+    func capitalizeFilterCoercesNonStrings() throws {
+        #expect(try Filters.capitalize([.undefined], kwargs: [:], env: env) == .string(""))
+        #expect(try Filters.capitalize([.null], kwargs: [:], env: env) == .string(""))
+        #expect(try Filters.capitalize([.int(42)], kwargs: [:], env: env) == .string("42"))
+        #expect(try Filters.capitalize([.string("hello")], kwargs: [:], env: env) == .string("Hello"))
+    }
+
+    @Test("title filter coerces non-strings (Jinja2 soft_str)")
+    func titleFilterCoercesNonStrings() throws {
+        #expect(try Filters.title([.undefined], kwargs: [:], env: env) == .string(""))
+        #expect(try Filters.title([.int(42)], kwargs: [:], env: env) == .string("42"))
+    }
+
+    @Test("trim filter coerces non-strings (Jinja2 soft_str)")
+    func trimFilterCoercesNonStrings() throws {
+        #expect(try Filters.trim([.undefined], kwargs: [:], env: env) == .string(""))
+        #expect(try Filters.trim([.int(42)], kwargs: [:], env: env) == .string("42"))
+    }
+
+    @Test("center filter coerces non-strings (Jinja2 soft_str)")
+    func centerFilterCoercesNonStrings() throws {
+        #expect(try Filters.center([.undefined, .int(4)], kwargs: [:], env: env) == .string("    "))
+        #expect(try Filters.center([.int(5), .int(1)], kwargs: [:], env: env) == .string("5"))
+        #expect(try Filters.center([.int(5), .int(5)], kwargs: [:], env: env) == .string("  5  "))
+    }
+
+    @Test("wordcount filter coerces non-strings (Jinja2 soft_str)")
+    func wordcountFilterCoercesNonStrings() throws {
+        #expect(try Filters.wordcount([.undefined], kwargs: [:], env: env) == .int(0))
+        #expect(try Filters.wordcount([.int(42)], kwargs: [:], env: env) == .int(1))
+    }
+
+    @Test("replace filter coerces non-strings (Jinja2 soft_str)")
+    func replaceFilterCoercesNonStrings() throws {
+        #expect(
+            try Filters.replace([.undefined, .string("a"), .string("b")], kwargs: [:], env: env)
+                == .string("")
+        )
+        #expect(
+            try Filters.replace([.int(42), .string("4"), .string("x")], kwargs: [:], env: env)
+                == .string("x2")
+        )
+        #expect(
+            try Filters.replace([.string("a1"), .int(1), .int(9)], kwargs: [:], env: env)
+                == .string("a9")
+        )
+    }
+
+    @Test("format filter coerces non-strings (Jinja2 soft_str)")
+    func formatFilterCoercesNonStrings() throws {
+        #expect(try Filters.format([.undefined], kwargs: [:], env: env) == .string(""))
+        #expect(try Filters.format([.int(42)], kwargs: [:], env: env) == .string("42"))
+        #expect(
+            try Filters.format([.string("n=%s"), .int(7)], kwargs: [:], env: env) == .string("n=7")
+        )
+    }
+
+    @Test("join filter coerces non-string separator (Jinja2 soft_str)")
+    func joinFilterCoercesNonStringSeparator() throws {
+        let values = [Value.string("a"), .string("b")]
+        #expect(
+            try Filters.join([.array(values), .int(0)], kwargs: [:], env: env) == .string("a0b")
+        )
+    }
+
     @Test("length filter for strings")
     func lengthFilterString() throws {
         let result = try Filters.length([.string("hello")], kwargs: [:], env: env)
@@ -731,11 +797,12 @@ struct FiltersTests {
         }
     }
 
-    @Test("join filter with non-string separator throws")
+    @Test("join filter coerces a non-string separator (like Jinja2) rather than throwing")
     func joinFilterNonStringSeparator() throws {
-        #expect(throws: JinjaError.self) {
-            try Filters.join([.array([.int(1)]), .int(42)], kwargs: [:], env: env)
-        }
+        #expect(
+            try Filters.join([.array([.int(1), .int(2)]), .int(42)], kwargs: [:], env: env)
+                == .string("1422")
+        )
     }
 
     @Test("default filter with boolean mode")
@@ -1343,10 +1410,10 @@ struct FiltersTests {
         #expect(result == .string(""))
     }
 
-    @Test("trim filter with non-string")
+    @Test("trim filter coerces a non-string (like Jinja2) rather than emptying")
     func trimFilterNonString() throws {
         let result = try Filters.trim([.int(42)], kwargs: [:], env: env)
-        #expect(result == .string(""))
+        #expect(result == .string("42"))
     }
 
     @Test("tojson filter with no args")
@@ -1375,16 +1442,16 @@ struct FiltersTests {
         }
     }
 
-    @Test("capitalize filter with non-string")
+    @Test("capitalize filter coerces a non-string (like Jinja2) rather than emptying")
     func capitalizeFilterNonString() throws {
         let result = try Filters.capitalize([.int(42)], kwargs: [:], env: env)
-        #expect(result == .string(""))
+        #expect(result == .string("42"))
     }
 
-    @Test("center filter with non-string returns input")
+    @Test("center filter coerces a non-string (like Jinja2) rather than returning input")
     func centerFilterNonString() throws {
-        let result = try Filters.center([.int(42), .int(10)], kwargs: [:], env: env)
-        #expect(result == .int(42))
+        let result = try Filters.center([.int(42), .int(6)], kwargs: [:], env: env)
+        #expect(result == .string("  42  "))
     }
 
     @Test("center filter missing width throws")
@@ -1605,22 +1672,22 @@ struct FiltersTests {
         #expect(result == .double(2.5))
     }
 
-    @Test("title filter with non-string")
+    @Test("title filter coerces a non-string (like Jinja2) rather than emptying")
     func titleFilterNonString() throws {
         let result = try Filters.title([.int(42)], kwargs: [:], env: env)
-        #expect(result == .string(""))
+        #expect(result == .string("42"))
     }
 
-    @Test("wordcount filter with non-string")
+    @Test("wordcount filter coerces a non-string (like Jinja2) rather than returning zero")
     func wordcountFilterNonString() throws {
         let result = try Filters.wordcount([.int(42)], kwargs: [:], env: env)
-        #expect(result == .int(0))
+        #expect(result == .int(1))
     }
 
-    @Test("replace filter with non-string returns input")
+    @Test("replace filter coerces a non-string (like Jinja2) rather than returning input")
     func replaceFilterNonString() throws {
-        let result = try Filters.replace([.int(42), .string("a"), .string("b")], kwargs: [:], env: env)
-        #expect(result == .int(42))
+        let result = try Filters.replace([.int(42), .string("4"), .string("x")], kwargs: [:], env: env)
+        #expect(result == .string("x2"))
     }
 
     @Test("replace filter with empty old string")


### PR DESCRIPTION
upper/lower throw JinjaError.runtime("... requires string") whenever the piped value isn't a Swift .string. This diverges from CPython Jinja2 — whose do_upper/do_lower apply soft_str, coercing any value (undefined/None -> "", numbers -> their string form) — and from other implementations such as llama.cpp's minja.

Real chat templates depend on the coercing behavior. Gemma's tool-schema template does {{ value['type'] | upper }}, and a JSON-Schema property using anyOf (Pydantic Optional[...]) has no scalar type, so value['type'] is undefined — which renders as "" under Jinja2/minja but raises under swift-jinja, breaking every tool-calling prompt with such a parameter.

Fix: coerce the input via Value.description (the same stringification the interpreter uses for {{ }} output) before casing, matching Jinja2's soft_str. Adds filter-level coercion tests (undefined/null/int) and a template regression ({{ missing | upper }} -> ""); updates the two edge-case tests that asserted the old throw.

This fixes loading models with tools like:
gemma-4-E2B-it-MLX
gemma-4-E4B-it-MLX
gemma-4-31b-it